### PR TITLE
DKASH v1.3.0.1 Update

### DIFF
--- a/DKASH-qt.pro
+++ b/DKASH-qt.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = DigitalKash-qt
-VERSION = 1.3.0.0
+VERSION = 1.3.0.1
 INCLUDEPATH += src src/json src/qt src/qt/plugins/mrichtexteditor
 QT += core gui widgets network printsupport
 DEFINES += ENABLE_WALLET

--- a/src/blockparams.cpp
+++ b/src/blockparams.cpp
@@ -1,7 +1,7 @@
-// Copyright (c) 2016-2023 The CryptoCoderz Team / Espers
-// Copyright (c) 2018-2023 The CryptoCoderz Team / INSaNe project
-// Copyright (c) 2018-2023 The Rubix project
-// Copyright (c) 2022-2023 The DigitalKash project
+// Copyright (c) 2016-2024 The CryptoCoderz Team / Espers
+// Copyright (c) 2018-2024 The CryptoCoderz Team / INSaNe project
+// Copyright (c) 2018-2024 The Rubix project
+// Copyright (c) 2022-2024 The DigitalKash project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/blockparams.h
+++ b/src/blockparams.h
@@ -1,7 +1,7 @@
-// Copyright (c) 2016-2023 The CryptoCoderz Team / Espers
-// Copyright (c) 2018-2023 The CryptoCoderz Team / INSaNe project
-// Copyright (c) 2018-2023 The Rubix project
-// Copyright (c) 2022-2023 The DigitalKash project
+// Copyright (c) 2016-2024 The CryptoCoderz Team / Espers
+// Copyright (c) 2018-2024 The CryptoCoderz Team / INSaNe project
+// Copyright (c) 2018-2024 The Rubix project
+// Copyright (c) 2022-2024 The DigitalKash project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_BLOCKPARAMS_H

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       1
 #define CLIENT_VERSION_MINOR       3
 #define CLIENT_VERSION_REVISION    0
-#define CLIENT_VERSION_BUILD       0
+#define CLIENT_VERSION_BUILD       1
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  true

--- a/src/deminode/demimodule.cpp
+++ b/src/deminode/demimodule.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 The Espers Project/CryptoCoderz Team
+// Copyright (c) 2021-2024 The Espers Project/CryptoCoderz Team
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/deminode/demimodule.h
+++ b/src/deminode/demimodule.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 The Espers Project/CryptoCoderz Team
+// Copyright (c) 2021-2024 The Espers Project/CryptoCoderz Team
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef DEMIMODULE_H

--- a/src/deminode/deminet.cpp
+++ b/src/deminode/deminet.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 The Espers Project/CryptoCoderz Team
+// Copyright (c) 2021-2024 The Espers Project/CryptoCoderz Team
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -26,7 +26,7 @@ bool fDemiPeerRelay(std::string peerAddr)
         return true;
     }
     // Failure if not found
-    LogPrintf("Demi-node System: fDemiPeerRelay - Peer: %s does NOT match any listed Demi-node!\n", peerAddr);
+    // LogPrintf("Demi-node System: fDemiPeerRelay - Peer: %s does NOT match any listed Demi-node!\n", peerAddr);
     return false;
 }
 

--- a/src/deminode/deminet.h
+++ b/src/deminode/deminet.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 The Espers Project/CryptoCoderz Team
+// Copyright (c) 2021-2024 The Espers Project/CryptoCoderz Team
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef DEMINET_H

--- a/src/deminode/demisync.cpp
+++ b/src/deminode/demisync.cpp
@@ -1,5 +1,60 @@
-// Copyright (c) 2021-2023 The Espers Project/CryptoCoderz Team
+// Copyright (c) 2021-2024 The Espers Project/CryptoCoderz Team
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "demisync.h"
+#include "deminet.h"
+#include "demimodule.h"
+
+static void DemiNodeSelect(bool demiSelectStatus, std::string demiSelectAddr)
+{
+        LOCK(cs_vNodes);
+        // Reset previously set data
+        fDemiFound = false;
+
+        // Loop through peers/nodes
+        BOOST_FOREACH(CNode* pnode, vNodes) {
+            // Skip obsolete nodes
+            if(pnode->nVersion < DEMINODE_VERSION) {
+                continue;
+            }
+
+            // See if we found a Demi-node
+            if(fDemiPeerRelay(pnode->addrName)) {
+                LogPrintf("Demi-node System: DemiNodeSelect - Selected a Demi-node successfully!\n");
+                demiSelectStatus = true;
+                demiSelectAddr = pnode->addrName;
+                // Toggle sync status and triggers
+                pnodeSync = pnode;
+                PushGetBlocks(pnode, pindexBest, uint256(0));
+                break;
+            }
+        }
+
+        // Return silently (success)
+        if(demiSelectStatus) {
+            return;
+        }
+
+        // Report failure
+        LogPrintf("Demi-node System: DemiNodeSelect - Could not select a Demi-node\n");
+}
+
+bool startDemiSync()
+{
+    // Set values
+    bool demiSelectStatus = false;
+    std::string demiSelectAddr = "";
+    // Fetch block data from Demi-nodes
+    DemiNodeSelect(demiSelectStatus, demiSelectAddr);
+
+    // Make sure we found a Demi-node
+    if(!demiSelectStatus) {
+        LogPrintf("Demi-node System: WARNING - No connected Demi-nodes found for Demi-sync!\n");
+        return false;
+    } else {
+        LogPrintf("Demi-node System: STATUS - Demi-sync has connected to %s and is downloading blocks!\n", demiSelectAddr.c_str());
+        // Report success if we reach this point
+        return true;
+    }
+}

--- a/src/deminode/demisync.h
+++ b/src/deminode/demisync.h
@@ -1,8 +1,9 @@
-// Copyright (c) 2021-2023 The Espers Project/CryptoCoderz Team
+// Copyright (c) 2021-2024 The Espers Project/CryptoCoderz Team
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef DEMISYNC_H
 #define DEMISYNC_H
 
+bool startDemiSync();
 
 #endif // DEMISYNC_H

--- a/src/fork.h
+++ b/src/fork.h
@@ -1,6 +1,6 @@
-// Copyright (c) 2016-2023 The CryptoCoderz Team / Espers
-// Copyright (c) 2018-2023 The Rubix project
-// Copyright (c) 2022-2023 The FrogCoin project
+// Copyright (c) 2016-2024 The CryptoCoderz Team / Espers
+// Copyright (c) 2018-2024 The Rubix project
+// Copyright (c) 2022-2024 The FrogCoin project
 // Copyright (c) 2023      The DigitalKash project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -15,8 +15,8 @@ static const int64_t nReservePhaseStart = 1;
 static const int64_t VELOCITY_TOGGLE = 175; // Implementation of the Velocity system into the chain.
 /** Velocity retarget toggle block */
 static const int64_t VELOCITY_TDIFF = 0; // Use Velocity's retargetting method.
-/** VRX Threshold update block */
-static const int64_t VELOCITY_THRESHOLD_2 = 162858; // Update VRX v3.6 retarget threshold.
+/** Velocity retarget toggle block */
+static const int64_t VELOCITY_THRESHOLD_2 = 162858; // Update Velocity retarget threshold.
 /** Protocol 3.0 toggle */
 inline bool IsProtocolV3(int64_t nTime) { return TestNet() || nTime > 1493596800; } // Mon, 01 May 2017 00:00:00 GMT
 /** Emissions output 2.0 toggle */

--- a/src/genesis.h
+++ b/src/genesis.h
@@ -1,6 +1,6 @@
-// Copyright (c) 2016-2023 The CryptoCoderz Team / Espers
-// Copyright (c) 2018-2023 The CryptoCoderz Team / INSaNe project
-// Copyright (c) 2016-2023 The Rubix project
+// Copyright (c) 2016-2024 The CryptoCoderz Team / Espers
+// Copyright (c) 2018-2024 The CryptoCoderz Team / INSaNe project
+// Copyright (c) 2016-2024 The Rubix project
 // Copyright (c) 2023 The DigitalKash project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1069,6 +1069,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         // Set Demi-node values
         uiInterface.InitMessage(_("Configuring Demi-node systems..."));
         std::string strOverrideDepth = GetArg("-demimaxdepth", "");
+        std::string strReorganizeType = GetArg("-demireorgtype", "");
         if(!strOverrideDepth.empty()) {
             std::istringstream(strOverrideDepth) >> BLOCK_REORG_OVERRIDE_DEPTH;
             if(BLOCK_REORG_OVERRIDE_DEPTH == 0) {
@@ -1078,6 +1079,16 @@ bool AppInit2(boost::thread_group& threadGroup)
             } else {
                 BLOCK_REORG_THRESHOLD = (BLOCK_REORG_MAX_DEPTH + BLOCK_REORG_OVERRIDE_DEPTH);
                 LogPrintf("Continuing with Demi-node depth override height of: %s\n", strOverrideDepth.c_str());
+            }
+        }
+        if(!strReorganizeType.empty()) {
+            std::istringstream(strReorganizeType) >> PEER_REORG_TYPE;
+            if(PEER_REORG_TYPE == 0) {
+                LogPrintf("Continuing with Demi-node ONLY reorganize authorization...\n");
+            } else if(PEER_REORG_TYPE < 0 || PEER_REORG_TYPE > 1) {
+                return InitError(_("Invalid Demi-node reorganize peer type selected, value must be either 0 or 1\n"));
+            } else {
+                LogPrintf("Continuing with Demi-node AND peer reorganize authorization\n");
             }
         }
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2573,6 +2573,10 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos, const u
 // Relay newly generated block, but don't accept it... Let network consensus decide
 bool NewBlockRelay(CBlock* pblock)
 {
+    // Verify we meet basic parameters
+    if (!Velocity(pindexBest, pblock, false)) {
+        return error("NewBlockRelay() : newly generated block failed to meet parameters \n");
+    }
     // Setup values
     uint256 hash = pblock->GetHash();
     bool relayFail = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2570,6 +2570,30 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos, const u
     return true;
 }
 
+// Relay newly generated block, but don't accept it... Let network consensus decide
+bool NewBlockRelay(CBlock* pblock)
+{
+    // Setup values
+    uint256 hash = pblock->GetHash();
+    bool relayFail = true;
+    // Relay New Block
+    int nBlockEstimate = Checkpoints::GetTotalBlocksEstimate();
+    LOCK(cs_vNodes);
+    BOOST_FOREACH(CNode* pnode, vNodes) {
+        if (nBestHeight > (pnode->nStartingHeight != -1 ? pnode->nStartingHeight - 2000 : nBlockEstimate)) {
+            pnode->PushInventory(CInv(MSG_BLOCK, hash));
+            relayFail = false;
+        }
+    }
+    // Return success if relayed to a peer/node
+    if (relayFail == false) {
+        return true;
+    }
+    // Fail if we can't relay
+    return error("NewBlockRelay() : newly generated block relay failed (Are we synced?) \n");
+
+}
+
 bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig) const
 {
     // These are checks that are independent of context

--- a/src/main.h
+++ b/src/main.h
@@ -148,6 +148,8 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals);
 void UnregisterNodeSignals(CNodeSignals& nodeSignals);
 
 void PushGetBlocks(CNode* pnode, CBlockIndex* pindexBegin, uint256 hashEnd);
+
+bool NewBlockRelay(CBlock* pblock);
 bool ProcessBlock(CNode* pfrom, CBlock* pblock);
 bool CheckDiskSpace(uint64_t nAdditionalBytes=0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");

--- a/src/main.h
+++ b/src/main.h
@@ -79,6 +79,8 @@ static int BLOCK_REORG_OVERRIDE_DEPTH = 0;
 static int BLOCK_REORG_THRESHOLD = BLOCK_REORG_MAX_DEPTH + BLOCK_REORG_OVERRIDE_DEPTH;
 /** Depth for rolling checkpoing block */
 static const int BLOCK_TEMP_CHECKPOINT_DEPTH = 120;
+/** Allow/Deny reorganize requests from peers as well as Demi-nodes */
+static int PEER_REORG_TYPE = 0;
 /** Velocity Factor handling toggle */
 inline bool FACTOR_TOGGLE(int nHeight) { return TestNet() || nHeight > 500; }
 /** Defaults to yes, adaptively increase/decrease max/min/priority along with the re-calculated block size **/

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2014-2015 The Dash developers
-// Copyright (c) 2016-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2016-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/masternodeconfig.h
+++ b/src/masternodeconfig.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2014-2015 The Dash developers
-// Copyright (c) 2016-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2016-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -581,9 +581,17 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
             wallet.mapRequestCount[hashBlock] = 0;
         }
 
+        // Depricated:
+        // ------------
         // Process this block the same as if we had received it from another node
-        if (!ProcessBlock(NULL, pblock))
-            return error("CheckWork() : ProcessBlock, block not accepted");
+        // if (!ProcessBlock(NULL, pblock))
+        //     return error("CheckWork() : ProcessBlock, block not accepted");
+        // ----------------
+        //
+        // Relay created block, but don't accept it... Let network consensus decide
+        if (!NewBlockRelay(pblock)) {
+            return error("CheckWork() : NewBlockRelay, block failed being relayed to peers!");
+        }
     }
 
     return true;
@@ -618,9 +626,17 @@ bool CheckStake(CBlock* pblock, CWallet& wallet)
             wallet.mapRequestCount[hashBlock] = 0;
         }
 
+        // Depricated:
+        // ------------
         // Process this block the same as if we had received it from another node
-        if (!ProcessBlock(NULL, pblock))
-            return error("CheckStake() : ProcessBlock, block not accepted");
+        // if (!ProcessBlock(NULL, pblock))
+        //     return error("CheckStake() : ProcessBlock, block not accepted");
+        // ----------------
+        //
+        // Relay created block, but don't accept it... Let network consensus decide
+        if (!NewBlockRelay(pblock)) {
+            return error("CheckStake() : NewBlockRelay, block failed being relayed to peers!");
+        }
         else
         {
             //ProcessBlock successful for PoS. now FixSpentCoins.

--- a/src/mining.h
+++ b/src/mining.h
@@ -1,7 +1,7 @@
-// Copyright (c) 2016-2023 The CryptoCoderz Team / Espers
-// Copyright (c) 2018-2023 The CryptoCoderz Team / INSaNe project
-// Copyright (c) 2018-2023 The Rubix project
-// Copyright (c) 2022-2023 The FrogCoin project
+// Copyright (c) 2016-2024 The CryptoCoderz Team / Espers
+// Copyright (c) 2018-2024 The CryptoCoderz Team / INSaNe project
+// Copyright (c) 2018-2024 The Rubix project
+// Copyright (c) 2022-2024 The FrogCoin project
 // Copyright (c) 2023      The DigitalKash project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -6,7 +6,6 @@
 #include "net.h"
 #include "main.h"
 #include "addrman.h"
-#include "chainparams.h"
 #include "chain.h"
 #include "ui_interface.h"
 #include "mnengine.h"
@@ -51,7 +50,7 @@ map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfReachable[NET_MAX] = {};
 static bool vfLimited[NET_MAX] = {};
 static CNode* pnodeLocalHost = NULL;
-static CNode* pnodeSync = NULL;
+CNode* pnodeSync = NULL;
 uint64_t nLocalHostNonce = 0;
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;

--- a/src/net.h
+++ b/src/net.h
@@ -138,6 +138,7 @@ extern uint64_t nLocalServices;
 extern uint64_t nLocalHostNonce;
 extern CAddrMan addrman;
 extern int nMaxConnections;
+extern CNode* pnodeSync;
 
 extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;

--- a/src/pas/pas.h
+++ b/src/pas/pas.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2022-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2022-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef PUBKEYALIASSERVICE_H

--- a/src/pas/pasconf.cpp
+++ b/src/pas/pasconf.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2022-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2022-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/pas/pasconf.h
+++ b/src/pas/pasconf.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2022-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2022-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/pas/pasengine.cpp
+++ b/src/pas/pasengine.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2022-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2022-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/pas/pasengine.h
+++ b/src/pas/pasengine.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2022-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2022-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/pas/pasman.h
+++ b/src/pas/pasman.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2022-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2022-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef PUBKEYALIASSERVICEMAN_H

--- a/src/pas/pasregister.cpp
+++ b/src/pas/pasregister.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2022-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2022-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/pas/pasregister.h
+++ b/src/pas/pasregister.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2022-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2022-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef PASREGISTER_H

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -541,7 +541,7 @@ void DigitalKashGUI::createToolBars()
 
 void DigitalKashGUI::setClientModel(ClientModel *clientModel)
 {
-    netLabel->setText("v1.3.0.0");// Version in GUI
+    netLabel->setText("v1.3.0.1");// Version in GUI
 
     this->clientModel = clientModel;
     if(clientModel)

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -113,8 +113,8 @@ color: rgb(255, 255, 255);</string>
         <string>Copyright © 2009-2014 The Bitcoin developers
 Copyright © 2012-2014 The NovaCoin developers
 Copyright © 2014-2016 The Dash developers
-Copyright © 2016-2020 The Espers Developers
-Copyright © 2020 The DigitalKash Developers</string>
+Copyright © 2016-2024 The Espers Developers
+Copyright © 2023-2024 The DigitalKash Developers</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/rpcconsolesettings.cpp
+++ b/src/qt/rpcconsolesettings.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The CryptoCoderz Team
+// Copyright (c) 2020-2024 The CryptoCoderz Team
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "rpcconsolesettings.h"

--- a/src/qt/settingspage.cpp
+++ b/src/qt/settingspage.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The CryptoCoderz Team
+// Copyright (c) 2020-2024 The CryptoCoderz Team
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "settingspage.h"

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -738,7 +738,14 @@ Value submitblock(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
     }
 
-    bool fAccepted = ProcessBlock(NULL, &block);
+    // Depricated:
+    // ------------
+    // bool fAccepted = ProcessBlock(NULL, &block);
+    // ----------------
+    //
+    // Relay created block, but don't accept it... Let network consensus decide
+    bool fAccepted = NewBlockRelay(&block);
+
     if (!fAccepted)
         return "rejected";
 

--- a/src/rpcpasengine.cpp
+++ b/src/rpcpasengine.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2022-2023 The CryptoCoderz Team / Espers project
-// Copyright (c) 2022-2023 The DigitalKash Project
+// Copyright (c) 2022-2024 The CryptoCoderz Team / Espers project
+// Copyright (c) 2022-2024 The DigitalKash Project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpcvelocity.cpp
+++ b/src/rpcvelocity.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2014 The Cryptocoin DigitalKashival Foundation
-// Copyright (c) 2015-2023 The CryptoCoderz Team / Espers
-// Copyright (c) 2018-2023 The Rubix Project
-// Copyright (c) 2022-2023 The DigitalKash project
+// Copyright (c) 2015-2024 The CryptoCoderz Team / Espers
+// Copyright (c) 2018-2024 The Rubix Project
+// Copyright (c) 2022-2024 The DigitalKash project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "main.h"

--- a/src/rpcvelocity.h
+++ b/src/rpcvelocity.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2014 The Cryptocoin DigitalKashival Foundation
-// Copyright (c) 2015-2023 The CryptoCoderz Team / Espers
-// Copyright (c) 2018-2023 The Rubix Project
-// Copyright (c) 2022-2023 The DigitalKash project
+// Copyright (c) 2015-2024 The CryptoCoderz Team / Espers
+// Copyright (c) 2018-2024 The Rubix Project
+// Copyright (c) 2022-2024 The DigitalKash project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2606,12 +2606,12 @@ Value cclistcoins(const Array& params, bool fHelp)
             "cclistcoins\n"
                         "CoinControl: list your spendable coins and their information\n");
 
-        Array result;
+    Array result;
 
-        std::vector<COutput> vCoins;
+    std::vector<COutput> vCoins;
     pwalletMain->AvailableCoins(vCoins);
 
-        BOOST_FOREACH(const COutput& out, vCoins)
+    BOOST_FOREACH(const COutput& out, vCoins)
     {
                 Object coutput;
                 int64_t nHeight = nBestHeight - out.nDepth;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1233,6 +1233,7 @@ void BuildConfigFile()
     fprintf(ConfFile, "maxconnections=150\n");
     fprintf(ConfFile, "deminodes=1\n");
     fprintf(ConfFile, "demimaxdepth=200\n");
+    fprintf(ConfFile, "demireorgtype=1\n");
     fprintf(ConfFile, "rpcuser=yourusername\n");
 
     char s[32];

--- a/src/velocity.cpp
+++ b/src/velocity.cpp
@@ -1,16 +1,12 @@
 // Copyright (c) 2014 The Cryptocoin DigitalKashival Foundation
-// Copyright (c) 2015-2023 The CryptoCoderz Team / Espers
-// Copyright (c) 2018-2023 The Rubix Project
-// Copyright (c) 2022-2023 The DigitalKash project
+// Copyright (c) 2015-2024 The CryptoCoderz Team / Espers
+// Copyright (c) 2018-2024 The Rubix Project
+// Copyright (c) 2022-2024 The DigitalKash project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "blockparams.h"
-#include "main.h"
 #include "txdb.h"
 #include "velocity.h"
-#include "rpcserver.h"
-#include "wallet.h"
 
 bool VELOCITY_FACTOR = false;
 uint256 RollingBlock;

--- a/src/velocity.h
+++ b/src/velocity.h
@@ -1,14 +1,14 @@
 // Copyright (c) 2014 The Cryptocoin DigitalKashival Foundation
-// Copyright (c) 2015-2023 The CryptoCoderz Team / Espers
-// Copyright (c) 2018-2023 The Rubix Project
-// Copyright (c) 2022-2023 The DigitalKash project
+// Copyright (c) 2015-2024 The CryptoCoderz Team / Espers
+// Copyright (c) 2018-2024 The Rubix Project
+// Copyright (c) 2022-2024 The DigitalKash project
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef VELOCITY_H
 #define VELOCITY_H 1
 
-#include "chainparams.h"
+#include "blockparams.h"
 #include "main.h"
 
 class CBlock;

--- a/src/version.h
+++ b/src/version.h
@@ -30,7 +30,7 @@ static const int DATABASE_VERSION = 70509;
 //
 // network protocol versioning
 //
-static const int PROTOCOL_VERSION = 62013;
+static const int PROTOCOL_VERSION = 62014;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Changelog
------------

- Cleaned up linking in velocity and miner files
- Added "demireorgtype" as a configurable variable allowing users to allow/deny Demi-node only network reorganization (If enabled allows "shallow" reorganize requests from standard peers to be allowed)
- Version bump
- Updated copyrights to 2024
- Updated sync selection logic
- Updated Demi-node feature
- Added Demi-sync functions
- Removed debug log spam
- Updated net files with public pnodeSync select/setting as apposed to segregated settings
- Added New Block Relay function as apposed to redundant work and self-acceptance. This corrects many things and stops self forking from mining/staking
- Updated NewBlockRelay handling to prevent possible banning from network by client spamming newly mined/minted blocks

NOT MANDATORY (But Highly Recommended)
----------------------------------------------------